### PR TITLE
Add timeout to `requests` calls

### DIFF
--- a/modules/pinata_api.py
+++ b/modules/pinata_api.py
@@ -1,8 +1,7 @@
-import json
-from typing import Type, Union, Dict, Any, List
+from typing import Dict, Any, List
 import requests
-import os
 from pathlib import Path
+from security import safe_requests
 
 
 def pinJSONToIPFS(
@@ -90,7 +89,7 @@ def pinSearch(
         "pinata_api_key": pinata_api_key,
         "pinata_secret_api_key": pinata_secret,
     }
-    response = requests.get(endpoint_uri, headers=HEADERS, timeout=60).json(timeout=60)
+    response = safe_requests.get(endpoint_uri, headers=HEADERS, timeout=60).json(timeout=60)
 
     # now get the actual data from this
     data = []
@@ -98,8 +97,7 @@ def pinSearch(
 
         for item in response["rows"]:
             ipfs_pin_hash = item["ipfs_pin_hash"]
-            hash_data = requests.get(
-                f"https://gateway.pinata.cloud/ipfs/{ipfs_pin_hash}", 
+            hash_data = safe_requests.get(f"https://gateway.pinata.cloud/ipfs/{ipfs_pin_hash}", 
             timeout=60).json(timeout=60)
             data.append(hash_data)
 

--- a/modules/pinata_api.py
+++ b/modules/pinata_api.py
@@ -31,7 +31,7 @@ def pinJSONToIPFS(
     }
 
     endpoint_uri = "https://api.pinata.cloud/pinning/pinJSONToIPFS"
-    response = requests.post(endpoint_uri, headers=HEADERS, json=ipfs_json)
+    response = requests.post(endpoint_uri, headers=HEADERS, json=ipfs_json, timeout=60)
     return response.json()
 
 
@@ -61,8 +61,8 @@ def pinContentToIPFS(
     with Path(filepath).open("rb") as fp:
         image_binary = fp.read()
         response = requests.post(
-            endpoint_uri, files={"file": (filename, image_binary)}, headers=HEADERS
-        )
+            endpoint_uri, files={"file": (filename, image_binary)}, headers=HEADERS, 
+        timeout=60)
         print(response.json())
 
         # response = requests.post(endpoint_uri, data=multipart_form_data, headers=HEADERS)
@@ -90,7 +90,7 @@ def pinSearch(
         "pinata_api_key": pinata_api_key,
         "pinata_secret_api_key": pinata_secret,
     }
-    response = requests.get(endpoint_uri, headers=HEADERS).json()
+    response = requests.get(endpoint_uri, headers=HEADERS, timeout=60).json(timeout=60)
 
     # now get the actual data from this
     data = []
@@ -99,8 +99,8 @@ def pinSearch(
         for item in response["rows"]:
             ipfs_pin_hash = item["ipfs_pin_hash"]
             hash_data = requests.get(
-                f"https://gateway.pinata.cloud/ipfs/{ipfs_pin_hash}"
-            ).json()
+                f"https://gateway.pinata.cloud/ipfs/{ipfs_pin_hash}", 
+            timeout=60).json(timeout=60)
             data.append(hash_data)
 
     # print(response.json())

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 streamlit
 web3
 requests
+security~=1.2.0

--- a/scripts/query_graph.py
+++ b/scripts/query_graph.py
@@ -32,7 +32,7 @@ def query_subgraph(api_endpoint: str, address: str, entity_name: str) -> List:
     """
     )
 
-    request = requests.post(api_endpoint, json={"query": query})
+    request = requests.post(api_endpoint, json={"query": query}, timeout=60)
 
     if request.status_code == 200:
         if "errors" in request.json():


### PR DESCRIPTION
Many developers will be surprised to learn that `requests` library calls do not include timeouts by default. This means that an attempted request could hang indefinitely if no connection is established or if no data is received from the server. 

The [requests documentation](https://requests.readthedocs.io/en/latest/user/advanced/#timeouts) suggests that most calls should explicitly include a `timeout` parameter. This codemod adds a default timeout value in order to set an upper bound on connection times and ensure that requests connect or fail in a timely manner. This value also ensures the connection will timeout if the server does not respond with data within a reasonable amount of time. 

While timeout values will be application dependent, we believe that this codemod adds a reasonable default that serves as an appropriate ceiling for most situations. 

Our changes look like the following:
```diff
 import requests
 
- requests.get("http://example.com")
+ requests.get("http://example.com", timeout=60)
```

<details>
  <summary>More reading</summary>

  * [https://docs.python-requests.org/en/master/user/quickstart/#timeouts](https://docs.python-requests.org/en/master/user/quickstart/#timeouts)
</details>

I have additional improvements ready for this repo! If you want to see them, leave the comment:
```
@pixeebot next
```
... and I will open a new PR right away!

Powered by: [pixeebot](https://docs.pixee.ai/) (codemod ID: [pixee:python/add-requests-timeouts](https://docs.pixee.ai/codemods/python/pixee_python_add-requests-timeouts)) ![](https://d1zaessa2hpsmj.cloudfront.net/pixel/v1/track?writeKey=2PI43jNm7atYvAuK7rJUz3Kcd6A&event=DRIP_PR%7Ccitizenjosh%2Fpolygon_nft_workshop%7Ccbcaddc23da05208549fcfaddb97b3ca29368f84)

<!--{"type":"DRIP","codemod":"pixee:python/add-requests-timeouts"}-->